### PR TITLE
Add configuration for Atomix clients

### DIFF
--- a/pkg/atomix/client.go
+++ b/pkg/atomix/client.go
@@ -24,15 +24,7 @@ import (
 	"github.com/atomix/go-framework/pkg/atomix/registry"
 	"github.com/atomix/go-local/pkg/atomix/local"
 	"net"
-	"os"
 	"time"
-)
-
-const (
-	atomixControllerEnv = "ATOMIX_CONTROLLER"
-	atomixNamespaceEnv  = "ATOMIX_NAMESPACE"
-	atomixAppEnv        = "ATOMIX_APP"
-	atomixRaftGroup     = "ATOMIX_RAFT"
 )
 
 const basePort = 45000
@@ -56,39 +48,22 @@ func StartLocalNode() (*atomix.Node, netutil.Address) {
 	panic("cannot find open port")
 }
 
-func getAtomixController() string {
-	return os.Getenv(atomixControllerEnv)
-}
-
-func getAtomixNamespace() string {
-	return os.Getenv(atomixNamespaceEnv)
-}
-
-func getAtomixScope() string {
-	return os.Getenv(atomixAppEnv)
-}
-
-// GetAtomixRaftGroup get the Atomix Raft group
-func GetAtomixRaftGroup() string {
-	return os.Getenv(atomixRaftGroup)
-}
-
-// GetAtomixClient returns the Atomix client
-func GetAtomixClient() (*client.Client, error) {
+// GetClient returns the Atomix client
+func GetClient(config Config) (*client.Client, error) {
 	opts := []client.Option{
-		client.WithNamespace(getAtomixNamespace()),
-		client.WithScope(getAtomixScope()),
+		client.WithNamespace(config.GetNamespace()),
+		client.WithScope(config.GetScope()),
 	}
-	return client.NewClient(getAtomixController(), opts...)
+	return client.NewClient(config.GetController(), opts...)
 }
 
-// GetAtomixDatabase returns the Atomix database
-func GetAtomixDatabase() (*client.Database, error) {
-	client, err := GetAtomixClient()
+// GetDatabase returns the Atomix database
+func GetDatabase(config Config, database string) (*client.Database, error) {
+	client, err := GetClient(config)
 	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	return client.GetDatabase(ctx, GetAtomixRaftGroup())
+	return client.GetDatabase(ctx, database)
 }

--- a/pkg/atomix/config.go
+++ b/pkg/atomix/config.go
@@ -1,0 +1,57 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomix
+
+import (
+	"fmt"
+	"os"
+)
+
+// Config is the Atomix configuration
+type Config struct {
+	// Controller is the Atomix controller address
+	Controller string `yaml:"controller,omitempty"`
+	// Namespace is the Atomix namespace
+	Namespace string `yaml:"namespace,omitempty"`
+	// Scope is the Atomix client/application scope
+	Scope string `yaml:"scope,omitempty"`
+}
+
+// GetController gets the Atomix controller address
+func (c Config) GetController() string {
+	if c.Controller == "" {
+		namespace := c.GetNamespace()
+		if namespace != "" {
+			c.Controller = fmt.Sprintf("atomix-controller.%s.svc.cluster.local:5679", namespace)
+		}
+	}
+	return c.Controller
+}
+
+// GetNamespace gets the Atomix client namespace
+func (c Config) GetNamespace() string {
+	if c.Namespace == "" {
+		c.Namespace = os.Getenv("POD_NAMESPACE")
+	}
+	return c.Namespace
+}
+
+// GetScope gets the Atomix client scope
+func (c Config) GetScope() string {
+	if c.Scope == "" {
+		c.Scope = c.GetNamespace()
+	}
+	return c.Scope
+}

--- a/pkg/atomix/config.go
+++ b/pkg/atomix/config.go
@@ -16,7 +16,7 @@ package atomix
 
 import (
 	"fmt"
-	"os"
+	"github.com/onosproject/onos-lib-go/pkg/env"
 )
 
 // Config is the Atomix configuration
@@ -27,6 +27,8 @@ type Config struct {
 	Namespace string `yaml:"namespace,omitempty"`
 	// Scope is the Atomix client/application scope
 	Scope string `yaml:"scope,omitempty"`
+	// Protocols is a mapping of protocol types to databases
+	Protocols map[string]string `yaml:"protocols"`
 }
 
 // GetController gets the Atomix controller address
@@ -43,7 +45,7 @@ func (c Config) GetController() string {
 // GetNamespace gets the Atomix client namespace
 func (c Config) GetNamespace() string {
 	if c.Namespace == "" {
-		c.Namespace = os.Getenv("POD_NAMESPACE")
+		c.Namespace = env.GetServiceNamespace()
 	}
 	return c.Namespace
 }
@@ -51,7 +53,18 @@ func (c Config) GetNamespace() string {
 // GetScope gets the Atomix client scope
 func (c Config) GetScope() string {
 	if c.Scope == "" {
+		c.Scope = env.GetServiceName()
+	}
+	if c.Scope == "" {
 		c.Scope = c.GetNamespace()
 	}
 	return c.Scope
+}
+
+// GetDatabase gets the database name for the given protocol
+func (c Config) GetDatabase(protocol string) string {
+	if db, ok := c.Protocols[protocol]; ok {
+		return db
+	}
+	return protocol
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,49 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import "os"
+
+// PodNamespace is the name of the environment variable containing the pod namespace
+const PodNamespace = "POD_NAMESPACE"
+
+// GetPodNamespace gets the pod namespace from the environment
+func GetPodNamespace() string {
+	return os.Getenv(PodNamespace)
+}
+
+// PodName is the name of the environment variable containing the pod name
+const PodName = "POD_NAME"
+
+// GetPodName gets the pod name from the environment
+func GetPodName() string {
+	return os.Getenv(PodName)
+}
+
+// ServiceNamespace is the name of the environment variable containing the service namespace
+const ServiceNamespace = "SERVICE_NAMESPACE"
+
+// GetServiceNamespace gets the service namespace from the environment
+func GetServiceNamespace() string {
+	return os.Getenv(ServiceNamespace)
+}
+
+// ServiceName is the name of the environment variable containing the service name
+const ServiceName = "SERVICE_NAME"
+
+// GetServiceName gets the service name from the environment
+func GetServiceName() string {
+	return os.Getenv(ServiceName)
+}


### PR DESCRIPTION
This PR adds a YAML tagged `Config` struct for Atomix clients and updates client factory functions to use the configuration.