### PR TITLE
Add cluster abstraction for east-west communication

### DIFF
--- a/pkg/atomix/client.go
+++ b/pkg/atomix/client.go
@@ -65,8 +65,8 @@ func GetClient(config Config) (*client.Client, error) {
 			return func(id peer.ID, server *grpc.Server) {
 				service(cluster.NodeID(id), server)
 			}
-		}
-		opts = append(opts, client.WithService(service(s)))
+		}(s)
+		opts = append(opts, client.WithService(service))
 	}
 	return client.New(config.GetController(), opts...)
 }

--- a/pkg/atomix/registry.go
+++ b/pkg/atomix/registry.go
@@ -1,0 +1,38 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomix
+
+import (
+	"github.com/onosproject/onos-lib-go/pkg/cluster"
+)
+
+var serviceRegistry = &ServiceRegistry{
+	services: make([]cluster.Service, 0),
+}
+
+// RegisterService registers a service with the Atomix cluster
+func RegisterService(service cluster.Service) {
+	serviceRegistry.Register(service)
+}
+
+// ServiceRegistry is a registry of Atomix services
+type ServiceRegistry struct {
+	services []cluster.Service
+}
+
+// Register registers a service
+func (r *ServiceRegistry) Register(service cluster.Service) {
+	r.services = append(r.services, service)
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,0 +1,140 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"github.com/atomix/go-client/pkg/client"
+	"github.com/atomix/go-client/pkg/client/peer"
+	"google.golang.org/grpc"
+	"io"
+	"sync"
+)
+
+// Service is a gRPC service
+type Service func(NodeID, *grpc.Server)
+
+// New creates a new cluster
+func New(client *client.Client) (Cluster, error) {
+	c := &atomixCluster{
+		group:    client.Group(),
+		replicas: make(ReplicaSet),
+		watchers: make([]chan<- ReplicaSet, 0),
+	}
+	if err := c.open(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Cluster is an interface for interacting with the onos-ric cluster
+type Cluster interface {
+	io.Closer
+
+	// Node returns the local node
+	Node() Node
+
+	// Replica returns a replica by ID
+	Replica(ReplicaID) *Replica
+
+	// Replicas returns the set of remote replicas
+	Replicas() ReplicaSet
+
+	// Watch watches the cluster for changes to the replicas
+	Watch(chan<- ReplicaSet) error
+}
+
+// atomixCluster is the default Atomix based cluster implementation
+type atomixCluster struct {
+	group    *peer.Group
+	replicas ReplicaSet
+	watchers []chan<- ReplicaSet
+	mu       sync.RWMutex
+}
+
+// open opens the cluster
+func (c *atomixCluster) open() error {
+	ch := make(chan peer.Set)
+	err := c.group.Watch(context.Background(), ch)
+	if err != nil {
+		return err
+	}
+	go func() {
+		for peers := range ch {
+			c.mu.Lock()
+			for id, peer := range peers {
+				_, ok := c.replicas[ReplicaID(id)]
+				if !ok {
+					c.replicas[ReplicaID(id)] = newReplica(ReplicaID(peer.ID), peer.Connect)
+				}
+			}
+			for id := range c.replicas {
+				_, ok := peers[peer.ID(id)]
+				if !ok {
+					delete(c.replicas, id)
+				}
+			}
+			c.mu.Unlock()
+
+			replicas := c.Replicas()
+			c.mu.RLock()
+			for _, watcher := range c.watchers {
+				watcher <- replicas
+			}
+			c.mu.RUnlock()
+		}
+	}()
+	return nil
+}
+
+// Node returns the local node
+func (c *atomixCluster) Node() Node {
+	member := c.group.Member()
+	if member == nil {
+		return Node{}
+	}
+	return newNode(NodeID(member.ID))
+}
+
+// Replica returns a replica by ID
+func (c *atomixCluster) Replica(id ReplicaID) *Replica {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.replicas[id]
+}
+
+// Replicas returns the set of all replicas
+func (c *atomixCluster) Replicas() ReplicaSet {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	replicas := make(ReplicaSet)
+	for id, replica := range c.replicas {
+		replicas[id] = replica
+	}
+	return replicas
+}
+
+// Watch watches the cluster for changes
+func (c *atomixCluster) Watch(ch chan<- ReplicaSet) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.watchers = append(c.watchers, ch)
+	return nil
+}
+
+// Close closes the cluster
+func (c *atomixCluster) Close() error {
+	return c.group.Close()
+}

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -1,0 +1,30 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+// newNode creates a new node
+func newNode(id NodeID) Node {
+	return Node{
+		ID: id,
+	}
+}
+
+// NodeID is a node identifier
+type NodeID string
+
+// Node is a cluster node
+type Node struct {
+	ID NodeID
+}

--- a/pkg/cluster/replica.go
+++ b/pkg/cluster/replica.go
@@ -1,0 +1,46 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"google.golang.org/grpc"
+)
+
+// newReplica creates a new replica
+func newReplica(id ReplicaID, connector func() (*grpc.ClientConn, error)) *Replica {
+	return &Replica{
+		Node:      newNode(NodeID(id)),
+		ID:        id,
+		connector: connector,
+	}
+}
+
+// ReplicaID is a replica identifier
+type ReplicaID NodeID
+
+// Replica is a cluster replica
+type Replica struct {
+	Node
+	ID        ReplicaID
+	connector func() (*grpc.ClientConn, error)
+}
+
+// Connect connects to the replica
+func (r *Replica) Connect() (*grpc.ClientConn, error) {
+	return r.connector()
+}
+
+// ReplicaSet is a set of replicas
+type ReplicaSet map[ReplicaID]*Replica

--- a/pkg/cluster/test.go
+++ b/pkg/cluster/test.go
@@ -1,0 +1,155 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"net"
+	"sync"
+)
+
+const bufSize = 1024 * 1024
+
+// NewTestFactory creates a new cluster factory
+func NewTestFactory(services ...Service) *TestFactory {
+	return &TestFactory{
+		clusters: make(map[NodeID]*localCluster),
+		services: services,
+	}
+}
+
+// TestFactory is a factory for creating test clusters
+type TestFactory struct {
+	clusters map[NodeID]*localCluster
+	services []Service
+	mu       sync.RWMutex
+}
+
+// NewCluster creates a new test cluster
+func (f *TestFactory) NewCluster(nodeID NodeID) (Cluster, error) {
+	f.mu.Lock()
+	cluster := &localCluster{
+		nodeID:   nodeID,
+		replicas: make(ReplicaSet),
+		watchers: make([]chan<- ReplicaSet, 0),
+	}
+	f.clusters[nodeID] = cluster
+	f.mu.Unlock()
+
+	if err := cluster.open(); err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+// closeCluster removes a cluster from the factory
+func (f *TestFactory) closeCluster(nodeID NodeID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.clusters, nodeID)
+}
+
+// getClusters returns a list of clusters
+func (f *TestFactory) getClusters() []*localCluster {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	clusters := make([]*localCluster, 0, len(f.clusters))
+	for _, cluster := range f.clusters {
+		clusters = append(clusters, cluster)
+	}
+	return clusters
+}
+
+type localCluster struct {
+	factory  *TestFactory
+	nodeID   NodeID
+	replicas ReplicaSet
+	watchers []chan<- ReplicaSet
+	mu       sync.RWMutex
+}
+
+func (c *localCluster) open() error {
+	server := grpc.NewServer()
+	for _, service := range c.factory.services {
+		service(c.nodeID, server)
+	}
+
+	lis := bufconn.Listen(bufSize)
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	clusters := c.factory.getClusters()
+	for _, cluster := range clusters {
+		cluster.addReplica(newReplica(ReplicaID(c.nodeID), func() (*grpc.ClientConn, error) {
+			return grpc.DialContext(context.Background(), "local", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+				return lis.Dial()
+			}))
+		}))
+	}
+	return nil
+}
+
+func (c *localCluster) Node() Node {
+	return newNode(c.nodeID)
+}
+
+func (c *localCluster) addReplica(replica *Replica) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.replicas[replica.ID]; !ok {
+		c.replicas[replica.ID] = replica
+	}
+}
+
+func (c *localCluster) removeReplica(replicaID ReplicaID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.replicas, replicaID)
+}
+
+func (c *localCluster) Replica(id ReplicaID) *Replica {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.replicas[id]
+}
+
+func (c *localCluster) Replicas() ReplicaSet {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	replicas := make(ReplicaSet)
+	for id, replica := range c.replicas {
+		replicas[id] = replica
+	}
+	return replicas
+}
+
+func (c *localCluster) Watch(ch chan<- ReplicaSet) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.watchers = append(c.watchers, ch)
+	return nil
+}
+
+func (c *localCluster) Close() error {
+	c.factory.closeCluster(c.nodeID)
+	clusters := c.factory.getClusters()
+	for _, cluster := range clusters {
+		cluster.removeReplica(ReplicaID(c.nodeID))
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a `cluster` package for cluster membership and east-west communication using gRPC. The cluster exposes the set of replicas in the service and provides an interface for connecting to replicas over gRPC. Services can be registered on the local node in `init` functions. For tests, a `cluster.TestFactory` constructs `Cluster` instances with members that can connect to each other over a local buffer connection.