### PR TITLE
Update cluster API to support gRPC options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Shopify/sarama v1.26.1
 	github.com/atomix/api v0.2.0
-	github.com/atomix/go-client v0.2.0
+	github.com/atomix/go-client v0.2.1
 	github.com/atomix/go-framework v0.2.0
 	github.com/atomix/go-local v0.2.0
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/atomix/go-client v0.1.1 h1:uaSuUyCWr6HgffMx1LQe8hNbi+4fvAs3AtVry0fPxh
 github.com/atomix/go-client v0.1.1/go.mod h1:Y3QjXcE6Sbb0QqMs1z9n0X3Mwafx26UYZAYf3qrVg24=
 github.com/atomix/go-client v0.2.0 h1:rJaK7MPid/XmYMtSn3RiIbcNHNBNh37d55+Vd/yqCog=
 github.com/atomix/go-client v0.2.0/go.mod h1:2vnbQIfU7NwfJo+HwB5oBYkK2Me2rPexTpC1vvhveF4=
+github.com/atomix/go-client v0.2.1 h1:vg0vyjTEvvDZhNis0rePw4Hjve3ayFqWOQ6qrKk/XkE=
+github.com/atomix/go-client v0.2.1/go.mod h1:2vnbQIfU7NwfJo+HwB5oBYkK2Me2rPexTpC1vvhveF4=
 github.com/atomix/go-framework v0.1.1 h1:qpUZERvPMUM1ndEbodk9qcgNa9YWqOPOJGTPdJVsagc=
 github.com/atomix/go-framework v0.1.1/go.mod h1:G7+oWIJUlx5Z8ohAzpIon6BAUPUo9VDx7w9AeQ6g3Wo=
 github.com/atomix/go-framework v0.2.0 h1:YppUrCL2D5FmovmK6FjP+XmNnO/IoSyQhLx48inIu8M=

--- a/pkg/atomix/config.go
+++ b/pkg/atomix/config.go
@@ -75,7 +75,7 @@ func (c Config) GetMember() string {
 // GetHost gets the Atomix peer host
 func (c Config) GetHost() string {
 	if c.Host == "" {
-		c.Host = env.GetPodName()
+		c.Host = env.GetPodID()
 	}
 	return c.Host
 }

--- a/pkg/cluster/replica.go
+++ b/pkg/cluster/replica.go
@@ -19,7 +19,7 @@ import (
 )
 
 // newReplica creates a new replica
-func newReplica(id ReplicaID, connector func() (*grpc.ClientConn, error)) *Replica {
+func newReplica(id ReplicaID, connector func(opts ...grpc.DialOption) (*grpc.ClientConn, error)) *Replica {
 	return &Replica{
 		Node:      newNode(NodeID(id)),
 		ID:        id,
@@ -34,12 +34,16 @@ type ReplicaID NodeID
 type Replica struct {
 	Node
 	ID        ReplicaID
-	connector func() (*grpc.ClientConn, error)
+	connector func(opts ...grpc.DialOption) (*grpc.ClientConn, error)
 }
 
 // Connect connects to the replica
-func (r *Replica) Connect() (*grpc.ClientConn, error) {
-	return r.connector()
+func (r *Replica) Connect(opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	options := []grpc.DialOption{
+		grpc.WithInsecure(),
+	}
+	options = append(options, opts...)
+	return r.connector(options...)
 }
 
 // ReplicaSet is a set of replicas

--- a/pkg/cluster/test.go
+++ b/pkg/cluster/test.go
@@ -100,15 +100,17 @@ func (c *localCluster) open() error {
 	for _, cluster := range clusters {
 		wg.Add(1)
 		go func(cluster *localCluster) {
-			cluster.addReplica(newReplica(ReplicaID(c.nodeID), func() (*grpc.ClientConn, error) {
-				return grpc.DialContext(context.Background(), "local", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			cluster.addReplica(newReplica(ReplicaID(c.nodeID), func(opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+				opts = append(opts, grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 					return c.lis.Dial()
-				}), grpc.WithInsecure())
+				}))
+				return grpc.DialContext(context.Background(), "local", opts...)
 			}))
-			c.addReplica(newReplica(ReplicaID(cluster.nodeID), func() (*grpc.ClientConn, error) {
-				return grpc.DialContext(context.Background(), "local", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			c.addReplica(newReplica(ReplicaID(cluster.nodeID), func(opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+				opts = append(opts, grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 					return cluster.lis.Dial()
-				}), grpc.WithInsecure())
+				}))
+				return grpc.DialContext(context.Background(), "local", opts...)
 			}))
 			wg.Done()
 		}(cluster)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -32,6 +32,14 @@ func GetPodName() string {
 	return os.Getenv(PodName)
 }
 
+// PodID is the name of the environment variable containing the pod network identifier
+const PodID = "POD_ID"
+
+// GetPodID gets the pod network identifier from the environment
+func GetPodID() string {
+	return os.Getenv(PodID)
+}
+
 // ServiceNamespace is the name of the environment variable containing the service namespace
 const ServiceNamespace = "SERVICE_NAMESPACE"
 


### PR DESCRIPTION
Update the Atomix client and add support for `DialOption`s on peer-to-peer gRPC connections.