### PR TITLE
Add authentication interceptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/atomix/go-local v0.2.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/gogo/protobuf v1.3.1
+	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/plar/go-adaptive-radix-tree v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -11,22 +12,12 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/atomix/api v0.1.0 h1:bnvw1x7NVTcOuxBb3XDdHQcU9cxAqwMzULwq3lAn9Fg=
-github.com/atomix/api v0.1.0/go.mod h1:G8fCdKYiPhZMYTgfz7QAtw6JqIfY2szigiz/gILNY50=
 github.com/atomix/api v0.2.0 h1:0e6xR8tNh71/4Ts05HHTMNCl2SXEqLXfg8gjehBxoSg=
 github.com/atomix/api v0.2.0/go.mod h1:G8fCdKYiPhZMYTgfz7QAtw6JqIfY2szigiz/gILNY50=
-github.com/atomix/go-client v0.1.1 h1:uaSuUyCWr6HgffMx1LQe8hNbi+4fvAs3AtVry0fPxhc=
-github.com/atomix/go-client v0.1.1/go.mod h1:Y3QjXcE6Sbb0QqMs1z9n0X3Mwafx26UYZAYf3qrVg24=
-github.com/atomix/go-client v0.2.0 h1:rJaK7MPid/XmYMtSn3RiIbcNHNBNh37d55+Vd/yqCog=
-github.com/atomix/go-client v0.2.0/go.mod h1:2vnbQIfU7NwfJo+HwB5oBYkK2Me2rPexTpC1vvhveF4=
 github.com/atomix/go-client v0.2.1 h1:vg0vyjTEvvDZhNis0rePw4Hjve3ayFqWOQ6qrKk/XkE=
 github.com/atomix/go-client v0.2.1/go.mod h1:2vnbQIfU7NwfJo+HwB5oBYkK2Me2rPexTpC1vvhveF4=
-github.com/atomix/go-framework v0.1.1 h1:qpUZERvPMUM1ndEbodk9qcgNa9YWqOPOJGTPdJVsagc=
-github.com/atomix/go-framework v0.1.1/go.mod h1:G7+oWIJUlx5Z8ohAzpIon6BAUPUo9VDx7w9AeQ6g3Wo=
 github.com/atomix/go-framework v0.2.0 h1:YppUrCL2D5FmovmK6FjP+XmNnO/IoSyQhLx48inIu8M=
 github.com/atomix/go-framework v0.2.0/go.mod h1:fRMu6i8RQUR2XGHnC4csasmAsDd3CPv3yAEK/9NYzZo=
-github.com/atomix/go-local v0.1.1 h1:fvErzig2F6kDVu/HRxeQMeRVoT5WqOwqH71uBJESZ6c=
-github.com/atomix/go-local v0.1.1/go.mod h1:nx3J3Xzu2K9t/7EdCc6rhW4AjGQ/cauhETTyoVZk+6k=
 github.com/atomix/go-local v0.2.0 h1:R5Iy1+lBdIHO9wPN5mawpnl+PIqGsvPbDZd+6uhQavM=
 github.com/atomix/go-local v0.2.0/go.mod h1:nbbobMfxgeseJcxihY9yfN+6F2LIRYAGvOBb7jrrb80=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -95,6 +86,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -235,6 +227,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -271,6 +264,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=

--- a/pkg/auth/jwt/jwt.go
+++ b/pkg/auth/jwt/jwt.go
@@ -1,0 +1,44 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+var log = logging.GetLogger("jwt")
+
+const (
+	HsSecretKey = "HS_SECRET_KEY"
+)
+
+func ParseToken(tokenString string) (*jwt.Token, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		// HS256, HS384, or HS512
+		if strings.HasPrefix(token.Method.Alg(), "HS") {
+			key := os.Getenv(HsSecretKey)
+			return []byte(key), nil
+		}
+		return nil, fmt.Errorf("unknown signining algorithm: %s", token.Method.Alg())
+	})
+
+	return token, err
+}

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -1,0 +1,57 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptors
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+
+	jwtauth "github.com/onosproject/onos-lib-go/pkg/auth/jwt"
+
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+)
+
+const (
+	ContextMetadataTokenKey = "bearer"
+)
+
+var log = logging.GetLogger("interceptors")
+
+// AuthenticationInterceptor
+func AuthenticationInterceptor(ctx context.Context) (context.Context, error) {
+	log.Info("authentication interceptor")
+	// Extract token from metadata in the context
+	tokenString, err := grpc_auth.AuthFromMD(ctx, ContextMetadataTokenKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse token to extract a jwt token
+	token, err := jwtauth.ParseToken(tokenString)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the token is valid
+	if !token.Valid {
+		return nil, fmt.Errorf("token is not valid %d", codes.Unauthenticated)
+	}
+	return ctx, nil
+
+}

--- a/pkg/northbound/server.go
+++ b/pkg/northbound/server.go
@@ -21,6 +21,10 @@ import (
 	"fmt"
 	"net"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"github.com/onosproject/onos-lib-go/pkg/interceptors"
+
 	"github.com/onosproject/onos-lib-go/pkg/certs"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"google.golang.org/grpc/credentials"
@@ -41,13 +45,19 @@ type Server struct {
 	services []Service
 }
 
+type SecurityConfig struct {
+	AuthenticationEnabled bool
+	AuthorizationEnabled  bool
+}
+
 // ServerConfig comprises a set of server configuration options.
 type ServerConfig struct {
-	CaPath   *string
-	KeyPath  *string
-	CertPath *string
-	Port     int16
-	Insecure bool
+	CaPath      *string
+	KeyPath     *string
+	CertPath    *string
+	Port        int16
+	Insecure    bool
+	SecurityCfg *SecurityConfig
 }
 
 // NewServer initializes gNMI server using the supplied configuration.
@@ -59,13 +69,14 @@ func NewServer(cfg *ServerConfig) *Server {
 }
 
 // NewServerConfig creates a server config created with the specified end-point security details.
-func NewServerConfig(caPath string, keyPath string, certPath string, port int16, secure bool) *ServerConfig {
+func NewServerConfig(caPath string, keyPath string, certPath string, port int16, secure bool, secCfg SecurityConfig) *ServerConfig {
 	return &ServerConfig{
-		Port:     port,
-		Insecure: secure,
-		CaPath:   &caPath,
-		KeyPath:  &keyPath,
-		CertPath: &certPath,
+		Port:        port,
+		Insecure:    secure,
+		CaPath:      &caPath,
+		KeyPath:     &keyPath,
+		CertPath:    &certPath,
+		SecurityCfg: &secCfg,
 	}
 }
 
@@ -118,6 +129,18 @@ func (s *Server) Serve(started func(string)) error {
 		return err
 	}
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
+	if s.cfg.SecurityCfg.AuthenticationEnabled {
+		log.Info("Enable Authentication")
+		opts = append(opts, grpc.UnaryInterceptor(
+			grpc_middleware.ChainUnaryServer(
+				grpc_auth.UnaryServerInterceptor(interceptors.AuthenticationInterceptor),
+			)))
+	}
+
+	if s.cfg.SecurityCfg.AuthorizationEnabled {
+		// TODO Add authorization interceptor
+
+	}
 	server := grpc.NewServer(opts...)
 	for i := range s.services {
 		s.services[i].Register(server)


### PR DESCRIPTION
This PR is a preliminary implementation of an authentication interceptor and its related library functions: 

1- The NB server library function is modified to potentially support authentication (at the moment) and authorization. A security config struct is introduced that should be initialized when we start the server which allows us to enable/disable authentication and authorization if it is needed.  

2- An authentication interceptor is added (it also uses grpc middleware library functions) to parse and validated a jwt token.  It checks the signing algorithm and verifies the signature is valid by reading the secret key from env variables. Technically, we should store secret keys in k8s as env variables.  



This is a work in progress and still lots of things need to be done to make it solid (e.g. supporting different signing algorithms, more checking and validation, etc)