### PR TITLE
Support RS family algorithms for authentication

### DIFF
--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -31,6 +31,10 @@ const (
 	SharedSecretKey = "SHARED_SECRET_KEY"
 	// RSAPublicKey an RSA public key
 	RSAPublicKey = "RSA_PUBLIC_KEY"
+	// HS prefix for HS family algorithms
+	HS = "HS"
+	// RS prefix for RS family algorithms
+	RS = "RS"
 )
 
 // JwtAuthenticator jwt authenticator
@@ -41,11 +45,11 @@ func (j *JwtAuthenticator) parseToken(tokenString string) (*jwt.Token, jwt.MapCl
 	claims := jwt.MapClaims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 		// HS256, HS384, or HS512
-		if strings.HasPrefix(token.Method.Alg(), "HS") {
+		if strings.HasPrefix(token.Method.Alg(), HS) {
 			key := os.Getenv(SharedSecretKey)
 			return []byte(key), nil
 			// RS256, RS384, or RS512
-		} else if strings.HasPrefix(token.Method.Alg(), "RS") {
+		} else if strings.HasPrefix(token.Method.Alg(), RS) {
 			key := os.Getenv(RSAPublicKey)
 			rsaPublicKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
 			if err != nil {

--- a/pkg/grpcinterceptors/grpcinterceptors.go
+++ b/pkg/grpcinterceptors/grpcinterceptors.go
@@ -43,7 +43,7 @@ func AuthenticationInterceptor(ctx context.Context) (context.Context, error) {
 
 	// Authenticate the jwt token
 	jwtAuth := new(auth.JwtAuthenticator)
-	_, err = jwtAuth.Authenticate(tokenString)
+	_, err = jwtAuth.ParseAndValidate(tokenString)
 	if err != nil {
 		return ctx, err
 	}


### PR DESCRIPTION
This PR adds supports for tokens that are signed using RS family algorithms. 

So far my assumption is that we store keys as secrets and make them accessible via environment variables in helm charts like this. If we need to read from file or use other ways to achieve the goal, we can change that. For example
```

env:
    - name: SHARED_SECRET_KEY
      valueFrom:
        secretKeyRef:
          name: shared-secret-key
          key: shared-secret-key
```