### PR TITLE
Block on GetDatabase call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Shopify/sarama v1.26.1
 	github.com/atomix/api v0.2.0
-	github.com/atomix/go-client v0.2.1
+	github.com/atomix/go-client v0.2.2
 	github.com/atomix/go-framework v0.2.0
 	github.com/atomix/go-local v0.2.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -15,7 +15,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
-	github.com/plar/go-adaptive-radix-tree v1.0.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/atomix/api v0.2.0 h1:0e6xR8tNh71/4Ts05HHTMNCl2SXEqLXfg8gjehBxoSg=
 github.com/atomix/api v0.2.0/go.mod h1:G8fCdKYiPhZMYTgfz7QAtw6JqIfY2szigiz/gILNY50=
-github.com/atomix/go-client v0.2.1 h1:vg0vyjTEvvDZhNis0rePw4Hjve3ayFqWOQ6qrKk/XkE=
-github.com/atomix/go-client v0.2.1/go.mod h1:2vnbQIfU7NwfJo+HwB5oBYkK2Me2rPexTpC1vvhveF4=
+github.com/atomix/go-client v0.2.2 h1:urKLLKNe42iKER9jn3S1wEcOFpiQO4iyohIYc6kRnWs=
+github.com/atomix/go-client v0.2.2/go.mod h1:2vnbQIfU7NwfJo+HwB5oBYkK2Me2rPexTpC1vvhveF4=
 github.com/atomix/go-framework v0.2.0 h1:YppUrCL2D5FmovmK6FjP+XmNnO/IoSyQhLx48inIu8M=
 github.com/atomix/go-framework v0.2.0/go.mod h1:fRMu6i8RQUR2XGHnC4csasmAsDd3CPv3yAEK/9NYzZo=
 github.com/atomix/go-local v0.2.0 h1:R5Iy1+lBdIHO9wPN5mawpnl+PIqGsvPbDZd+6uhQavM=
@@ -139,8 +139,6 @@ github.com/pierrec/lz4 v2.4.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/plar/go-adaptive-radix-tree v1.0.1 h1:J+2qrXaKWLACw59s8SlTVYYxWjlUr/BlCsfkAzn96/0=
-github.com/plar/go-adaptive-radix-tree v1.0.1/go.mod h1:Ot8d28EII3i7Lv4PSvBlF8ejiD/CtRYDuPsySJbSaK8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=

--- a/pkg/atomix/client.go
+++ b/pkg/atomix/client.go
@@ -17,9 +17,6 @@ package atomix
 import (
 	"context"
 	"fmt"
-	"net"
-	"time"
-
 	"github.com/atomix/api/proto/atomix/database"
 	"github.com/atomix/go-client/pkg/client"
 	"github.com/atomix/go-client/pkg/client/peer"
@@ -29,6 +26,7 @@ import (
 	"github.com/atomix/go-local/pkg/atomix/local"
 	"github.com/onosproject/onos-lib-go/pkg/cluster"
 	"google.golang.org/grpc"
+	"net"
 )
 
 const basePort = 45000
@@ -87,7 +85,5 @@ func GetDatabase(config Config, database string) (*client.Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	return client.GetDatabase(ctx, database)
+	return client.GetDatabase(context.Background(), database)
 }


### PR DESCRIPTION
This PR removes the timeout from the `GetDatabase` utility function to get an Atomix database. This ensures services block and do not restart while a database is starting up.