### PR TITLE
Support typed logger fields for structured logging

### DIFF
--- a/pkg/logging/field.go
+++ b/pkg/logging/field.go
@@ -28,6 +28,7 @@ type zapField struct {
 	field zap.Field
 }
 
+// Name returns the field name
 func (f *zapField) Name() string {
 	return f.field.Key
 }
@@ -36,276 +37,322 @@ func (f *zapField) getZapField() zap.Field {
 	return f.field
 }
 
+// String creates a named string field
 func String(name string, value string) Field {
 	return &zapField{
 		field: zap.String(name, value),
 	}
 }
 
+// Stringp creates a named string pointer field
 func Stringp(name string, value *string) Field {
 	return &zapField{
 		field: zap.Stringp(name, value),
 	}
 }
 
+// Strings creates a named string slice field
 func Strings(name string, value []string) Field {
 	return &zapField{
 		field: zap.Strings(name, value),
 	}
 }
 
+// Int creates a named int field
 func Int(name string, value int) Field {
 	return &zapField{
 		field: zap.Int(name, value),
 	}
 }
 
+// Intp creates a named int pointer field
 func Intp(name string, value *int) Field {
 	return &zapField{
 		field: zap.Intp(name, value),
 	}
 }
 
+// Ints creates a named int slice field
 func Ints(name string, value []int) Field {
 	return &zapField{
 		field: zap.Ints(name, value),
 	}
 }
 
+// Int32 creates a named int32 field
 func Int32(name string, value int32) Field {
 	return &zapField{
 		field: zap.Int32(name, value),
 	}
 }
 
+// Int32p creates a named int32 pointer field
 func Int32p(name string, value *int32) Field {
 	return &zapField{
 		field: zap.Int32p(name, value),
 	}
 }
 
+// Int32s creates a named int32 slice field
 func Int32s(name string, value []int32) Field {
 	return &zapField{
 		field: zap.Int32s(name, value),
 	}
 }
 
+// Int64 creates a named int64 field
 func Int64(name string, value int64) Field {
 	return &zapField{
 		field: zap.Int64(name, value),
 	}
 }
 
+// Int64p creates a named int64 pointer field
 func Int64p(name string, value *int64) Field {
 	return &zapField{
 		field: zap.Int64p(name, value),
 	}
 }
 
+// Int64s creates a named int64 slice field
 func Int64s(name string, value []int64) Field {
 	return &zapField{
 		field: zap.Int64s(name, value),
 	}
 }
 
+// Uint creates a named uint field
 func Uint(name string, value uint) Field {
 	return &zapField{
 		field: zap.Uint(name, value),
 	}
 }
 
+// Uintp creates a named uint pointer field
 func Uintp(name string, value *uint) Field {
 	return &zapField{
 		field: zap.Uintp(name, value),
 	}
 }
 
+// Uints creates a named uint slice field
 func Uints(name string, value []uint) Field {
 	return &zapField{
 		field: zap.Uints(name, value),
 	}
 }
 
+// Uint32 creates a named uint32 field
 func Uint32(name string, value uint32) Field {
 	return &zapField{
 		field: zap.Uint32(name, value),
 	}
 }
 
+// Uint32p creates a named uint32 pointer field
 func Uint32p(name string, value *uint32) Field {
 	return &zapField{
 		field: zap.Uint32p(name, value),
 	}
 }
 
+// Uint32s creates a named uint32 slice field
 func Uint32s(name string, value []uint32) Field {
 	return &zapField{
 		field: zap.Uint32s(name, value),
 	}
 }
 
+// Uint64 creates a named uint64 field
 func Uint64(name string, value uint64) Field {
 	return &zapField{
 		field: zap.Uint64(name, value),
 	}
 }
 
+// Uint64p creates a named uint64 pointer field
 func Uint64p(name string, value *uint64) Field {
 	return &zapField{
 		field: zap.Uint64p(name, value),
 	}
 }
 
+// Uint64s creates a named uint64 slice field
 func Uint64s(name string, value []uint64) Field {
 	return &zapField{
 		field: zap.Uint64s(name, value),
 	}
 }
 
+// Float32 creates a named float32 field
 func Float32(name string, value float32) Field {
 	return &zapField{
 		field: zap.Float32(name, value),
 	}
 }
 
+// Float32p creates a named float32 pointer field
 func Float32p(name string, value *float32) Field {
 	return &zapField{
 		field: zap.Float32p(name, value),
 	}
 }
 
+// Float32s creates a named float32 slice field
 func Float32s(name string, value []float32) Field {
 	return &zapField{
 		field: zap.Float32s(name, value),
 	}
 }
 
+// Float64 creates a named float64 field
 func Float64(name string, value float64) Field {
 	return &zapField{
 		field: zap.Float64(name, value),
 	}
 }
 
+// Float64p creates a named float64 pointer field
 func Float64p(name string, value *float64) Field {
 	return &zapField{
 		field: zap.Float64p(name, value),
 	}
 }
 
+// Float64s creates a named float64 slice field
 func Float64s(name string, value []float64) Field {
 	return &zapField{
 		field: zap.Float64s(name, value),
 	}
 }
 
+// Complex64 creates a named complex64 field
 func Complex64(name string, value complex64) Field {
 	return &zapField{
 		field: zap.Complex64(name, value),
 	}
 }
 
+// Complex64p creates a named complex64 pointer field
 func Complex64p(name string, value *complex64) Field {
 	return &zapField{
 		field: zap.Complex64p(name, value),
 	}
 }
 
+// Complex64s creates a named complex64 slice field
 func Complex64s(name string, value []complex64) Field {
 	return &zapField{
 		field: zap.Complex64s(name, value),
 	}
 }
 
+// Complex128 creates a named complex128 field
 func Complex128(name string, value complex128) Field {
 	return &zapField{
 		field: zap.Complex128(name, value),
 	}
 }
 
+// Complex128p creates a named complex128 pointer field
 func Complex128p(name string, value *complex128) Field {
 	return &zapField{
 		field: zap.Complex128p(name, value),
 	}
 }
 
+// Complex128s creates a named complex128 slice field
 func Complex128s(name string, value []complex128) Field {
 	return &zapField{
 		field: zap.Complex128s(name, value),
 	}
 }
 
+// Bool creates a named bool field
 func Bool(name string, value bool) Field {
 	return &zapField{
 		field: zap.Bool(name, value),
 	}
 }
 
+// Boolp creates a named bool pointer field
 func Boolp(name string, value *bool) Field {
 	return &zapField{
 		field: zap.Boolp(name, value),
 	}
 }
 
+// Bools creates a named bool slice field
 func Bools(name string, value []bool) Field {
 	return &zapField{
 		field: zap.Bools(name, value),
 	}
 }
 
+// Time creates a named Time field
 func Time(name string, value time.Time) Field {
 	return &zapField{
 		field: zap.Time(name, value),
 	}
 }
 
+// Timep creates a named Time pointer field
 func Timep(name string, value *time.Time) Field {
 	return &zapField{
 		field: zap.Timep(name, value),
 	}
 }
 
+// Times creates a named Time slice field
 func Times(name string, value []time.Time) Field {
 	return &zapField{
 		field: zap.Times(name, value),
 	}
 }
 
+// Duration creates a named Duration field
 func Duration(name string, value time.Duration) Field {
 	return &zapField{
 		field: zap.Duration(name, value),
 	}
 }
 
+// Durationp creates a named Duration pointer field
 func Durationp(name string, value *time.Duration) Field {
 	return &zapField{
 		field: zap.Durationp(name, value),
 	}
 }
 
+// Durations creates a named Duration slice field
 func Durations(name string, value []time.Duration) Field {
 	return &zapField{
 		field: zap.Durations(name, value),
 	}
 }
 
+// Byte creates a named byte field
 func Byte(name string, value byte) Field {
 	return &zapField{
 		field: zap.Binary(name, []byte{value}),
 	}
 }
 
+// Bytes creates a named byte slice field
 func Bytes(name string, value []byte) Field {
 	return &zapField{
 		field: zap.Binary(name, value),
 	}
 }
 
+// ByteString creates a named byte string field
 func ByteString(name string, value []byte) Field {
 	return &zapField{
 		field: zap.ByteString(name, value),
 	}
 }
 
+// ByteStrings creates a named byte string slice field
 func ByteStrings(name string, value [][]byte) Field {
 	return &zapField{
 		field: zap.ByteStrings(name, value),

--- a/pkg/logging/field.go
+++ b/pkg/logging/field.go
@@ -1,0 +1,313 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"go.uber.org/zap"
+	"time"
+)
+
+// Field is a structured logger field
+type Field interface {
+	getZapField() zap.Field
+}
+
+type zapField struct {
+	field zap.Field
+}
+
+func (f *zapField) Name() string {
+	return f.field.Key
+}
+
+func (f *zapField) getZapField() zap.Field {
+	return f.field
+}
+
+func String(name string, value string) Field {
+	return &zapField{
+		field: zap.String(name, value),
+	}
+}
+
+func Stringp(name string, value *string) Field {
+	return &zapField{
+		field: zap.Stringp(name, value),
+	}
+}
+
+func Strings(name string, value []string) Field {
+	return &zapField{
+		field: zap.Strings(name, value),
+	}
+}
+
+func Int(name string, value int) Field {
+	return &zapField{
+		field: zap.Int(name, value),
+	}
+}
+
+func Intp(name string, value *int) Field {
+	return &zapField{
+		field: zap.Intp(name, value),
+	}
+}
+
+func Ints(name string, value []int) Field {
+	return &zapField{
+		field: zap.Ints(name, value),
+	}
+}
+
+func Int32(name string, value int32) Field {
+	return &zapField{
+		field: zap.Int32(name, value),
+	}
+}
+
+func Int32p(name string, value *int32) Field {
+	return &zapField{
+		field: zap.Int32p(name, value),
+	}
+}
+
+func Int32s(name string, value []int32) Field {
+	return &zapField{
+		field: zap.Int32s(name, value),
+	}
+}
+
+func Int64(name string, value int64) Field {
+	return &zapField{
+		field: zap.Int64(name, value),
+	}
+}
+
+func Int64p(name string, value *int64) Field {
+	return &zapField{
+		field: zap.Int64p(name, value),
+	}
+}
+
+func Int64s(name string, value []int64) Field {
+	return &zapField{
+		field: zap.Int64s(name, value),
+	}
+}
+
+func Uint(name string, value uint) Field {
+	return &zapField{
+		field: zap.Uint(name, value),
+	}
+}
+
+func Uintp(name string, value *uint) Field {
+	return &zapField{
+		field: zap.Uintp(name, value),
+	}
+}
+
+func Uints(name string, value []uint) Field {
+	return &zapField{
+		field: zap.Uints(name, value),
+	}
+}
+
+func Uint32(name string, value uint32) Field {
+	return &zapField{
+		field: zap.Uint32(name, value),
+	}
+}
+
+func Uint32p(name string, value *uint32) Field {
+	return &zapField{
+		field: zap.Uint32p(name, value),
+	}
+}
+
+func Uint32s(name string, value []uint32) Field {
+	return &zapField{
+		field: zap.Uint32s(name, value),
+	}
+}
+
+func Uint64(name string, value uint64) Field {
+	return &zapField{
+		field: zap.Uint64(name, value),
+	}
+}
+
+func Uint64p(name string, value *uint64) Field {
+	return &zapField{
+		field: zap.Uint64p(name, value),
+	}
+}
+
+func Uint64s(name string, value []uint64) Field {
+	return &zapField{
+		field: zap.Uint64s(name, value),
+	}
+}
+
+func Float32(name string, value float32) Field {
+	return &zapField{
+		field: zap.Float32(name, value),
+	}
+}
+
+func Float32p(name string, value *float32) Field {
+	return &zapField{
+		field: zap.Float32p(name, value),
+	}
+}
+
+func Float32s(name string, value []float32) Field {
+	return &zapField{
+		field: zap.Float32s(name, value),
+	}
+}
+
+func Float64(name string, value float64) Field {
+	return &zapField{
+		field: zap.Float64(name, value),
+	}
+}
+
+func Float64p(name string, value *float64) Field {
+	return &zapField{
+		field: zap.Float64p(name, value),
+	}
+}
+
+func Float64s(name string, value []float64) Field {
+	return &zapField{
+		field: zap.Float64s(name, value),
+	}
+}
+
+func Complex64(name string, value complex64) Field {
+	return &zapField{
+		field: zap.Complex64(name, value),
+	}
+}
+
+func Complex64p(name string, value *complex64) Field {
+	return &zapField{
+		field: zap.Complex64p(name, value),
+	}
+}
+
+func Complex64s(name string, value []complex64) Field {
+	return &zapField{
+		field: zap.Complex64s(name, value),
+	}
+}
+
+func Complex128(name string, value complex128) Field {
+	return &zapField{
+		field: zap.Complex128(name, value),
+	}
+}
+
+func Complex128p(name string, value *complex128) Field {
+	return &zapField{
+		field: zap.Complex128p(name, value),
+	}
+}
+
+func Complex128s(name string, value []complex128) Field {
+	return &zapField{
+		field: zap.Complex128s(name, value),
+	}
+}
+
+func Bool(name string, value bool) Field {
+	return &zapField{
+		field: zap.Bool(name, value),
+	}
+}
+
+func Boolp(name string, value *bool) Field {
+	return &zapField{
+		field: zap.Boolp(name, value),
+	}
+}
+
+func Bools(name string, value []bool) Field {
+	return &zapField{
+		field: zap.Bools(name, value),
+	}
+}
+
+func Time(name string, value time.Time) Field {
+	return &zapField{
+		field: zap.Time(name, value),
+	}
+}
+
+func Timep(name string, value *time.Time) Field {
+	return &zapField{
+		field: zap.Timep(name, value),
+	}
+}
+
+func Times(name string, value []time.Time) Field {
+	return &zapField{
+		field: zap.Times(name, value),
+	}
+}
+
+func Duration(name string, value time.Duration) Field {
+	return &zapField{
+		field: zap.Duration(name, value),
+	}
+}
+
+func Durationp(name string, value *time.Duration) Field {
+	return &zapField{
+		field: zap.Durationp(name, value),
+	}
+}
+
+func Durations(name string, value []time.Duration) Field {
+	return &zapField{
+		field: zap.Durations(name, value),
+	}
+}
+
+func Byte(name string, value byte) Field {
+	return &zapField{
+		field: zap.Binary(name, []byte{value}),
+	}
+}
+
+func Bytes(name string, value []byte) Field {
+	return &zapField{
+		field: zap.Binary(name, value),
+	}
+}
+
+func ByteString(name string, value []byte) Field {
+	return &zapField{
+		field: zap.ByteString(name, value),
+	}
+}
+
+func ByteStrings(name string, value [][]byte) Field {
+	return &zapField{
+		field: zap.ByteStrings(name, value),
+	}
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -131,6 +131,7 @@ func newZapLogger(config Config, loggerConfig LoggerConfig) (*zapLogger, error) 
 		loggerConfig: loggerConfig,
 		children:     make(map[string]*zapLogger),
 		outputs:      outputs,
+		mu:           &sync.RWMutex{},
 	}
 	logger.level.Store(level)
 	logger.defaultLevel.Store(defaultLevel)
@@ -143,7 +144,7 @@ type zapLogger struct {
 	loggerConfig LoggerConfig
 	children     map[string]*zapLogger
 	outputs      []*zapOutput
-	mu           sync.RWMutex
+	mu           *sync.RWMutex
 	level        atomic.Value
 	defaultLevel atomic.Value
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -57,8 +57,8 @@ type Logger interface {
 	// GetLogger gets a descendant of this Logger
 	GetLogger(names ...string) Logger
 
-	// GetLevel returns the logger's level
-	GetLevel() Level
+	// Level returns the logger's level
+	Level() Level
 
 	// SetLevel sets the logger's level
 	SetLevel(level Level)
@@ -219,12 +219,12 @@ func (l *zapLogger) getChild(name string) (*zapLogger, error) {
 	}
 
 	// Set the default log level on the child.
-	logger.setDefaultLevel(l.GetLevel())
+	logger.setDefaultLevel(l.Level())
 	l.children[name] = logger
 	return logger, nil
 }
 
-func (l *zapLogger) GetLevel() Level {
+func (l *zapLogger) Level() Level {
 	level := l.level.Load().(*Level)
 	if level != nil {
 		return *level
@@ -278,7 +278,7 @@ func (l *zapLogger) Sync() error {
 }
 
 func (l *zapLogger) log(level Level, template string, args []interface{}, fields []Field, logger func(output Output, msg string, fields []Field)) {
-	if l.GetLevel() > level {
+	if l.Level() > level {
 		return
 	}
 

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -34,25 +34,25 @@ func TestLoggerConfig(t *testing.T) {
 	logger := GetLogger()
 	assert.Equal(t, InfoLevel, logger.GetLevel())
 	logger.Debug("should not be printed")
-	logger.Info("should be printed")
+	logger.Infof("should be %s", "printed")
 
 	// The "test" logger should inherit the INFO level from the root logger
-	logger = GetLogger("test")
+	logger = GetLogger("test").WithFields(Bool("printed", true))
 	assert.Equal(t, InfoLevel, logger.GetLevel())
-	logger.Debug("should not be printed")
-	logger.Info("should be printed")
+	logger.Debugf("should %s be", "not")
+	logger.Info("should be")
 
 	// The "test/1" logger should be configured with DEBUG level
 	logger = GetLogger("test", "1")
 	assert.Equal(t, DebugLevel, logger.GetLevel())
-	logger.Debug("should be printed")
-	logger.Info("should be printed")
+	logger.Debugw("should be", Bool("printed", true))
+	logger.Infow("should be", Bool("printed", true))
 
 	// The "test/1/2" logger should inherit the DEBUG level from "test/1"
-	logger = GetLogger("test", "1", "2")
+	logger = GetLogger("test", "1", "2").WithFields(Bool("printed", true))
 	assert.Equal(t, DebugLevel, logger.GetLevel())
-	logger.Debug("should be printed")
-	logger.Info("should be printed")
+	logger.Debugw("printed", String("should", "be"))
+	logger.Infow("printed", String("should", "be"))
 
 	// The "test" logger should still inherit the INFO level from the root logger
 	logger = GetLogger("test")
@@ -64,14 +64,14 @@ func TestLoggerConfig(t *testing.T) {
 	logger = GetLogger("test", "2")
 	assert.Equal(t, WarnLevel, logger.GetLevel())
 	logger.Debug("should not be printed")
-	logger.Info("should not be printed")
-	logger.Warn("should be printed twice")
+	logger.Infow("should not be", Bool("printed", true))
+	logger.Warnw("should be printed", Int("times", 2))
 
 	// The "test/2/3" logger should be configured with INFO level
 	logger = GetLogger("test", "2", "3")
 	assert.Equal(t, InfoLevel, logger.GetLevel())
 	logger.Debug("should not be printed")
-	logger.Info("should be printed twice")
+	logger.Infow("should be printed", Int("times", 2))
 	logger.Warn("should be printed twice")
 
 	// The "test/2/4" logger should inherit the WARN level from "test/2"
@@ -85,8 +85,8 @@ func TestLoggerConfig(t *testing.T) {
 	logger = GetLogger("test/2")
 	logger.SetLevel(DebugLevel)
 	assert.Equal(t, DebugLevel, logger.GetLevel())
-	logger.Debug("should be printed")
-	logger.Info("should be printed twice")
+	logger.Debugw("should be", Bool("printed", true))
+	logger.Infow("should be printed", Int("times", 2))
 	logger.Warn("should be printed twice")
 
 	// The "test/2/3" logger should not inherit the change to the "test/2" logger since its level has been explicitly set

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -32,51 +32,51 @@ func TestLoggerConfig(t *testing.T) {
 
 	// The root logger should be configured with INFO level
 	logger := GetLogger()
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Infof("should be %s", "printed")
 
 	// The "test" logger should inherit the INFO level from the root logger
 	logger = GetLogger("test").WithFields(Bool("printed", true))
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debugf("should %s be", "not")
 	logger.Info("should be")
 
 	// The "test/1" logger should be configured with DEBUG level
 	logger = GetLogger("test", "1")
-	assert.Equal(t, DebugLevel, logger.GetLevel())
+	assert.Equal(t, DebugLevel, logger.Level())
 	logger.Debugw("should be", Bool("printed", true))
 	logger.Infow("should be", Bool("printed", true))
 
 	// The "test/1/2" logger should inherit the DEBUG level from "test/1"
 	logger = GetLogger("test", "1", "2").WithFields(Bool("printed", true))
-	assert.Equal(t, DebugLevel, logger.GetLevel())
+	assert.Equal(t, DebugLevel, logger.Level())
 	logger.Debugw("printed", String("should", "be"))
 	logger.Infow("printed", String("should", "be"))
 
 	// The "test" logger should still inherit the INFO level from the root logger
 	logger = GetLogger("test")
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Info("should be printed")
 
 	// The "test/2" logger should be configured with WARN level
 	logger = GetLogger("test", "2")
-	assert.Equal(t, WarnLevel, logger.GetLevel())
+	assert.Equal(t, WarnLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Infow("should not be", Bool("printed", true))
 	logger.Warnw("should be printed", Int("times", 2))
 
 	// The "test/2/3" logger should be configured with INFO level
 	logger = GetLogger("test", "2", "3")
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Infow("should be printed", Int("times", 2))
 	logger.Warn("should be printed twice")
 
 	// The "test/2/4" logger should inherit the WARN level from "test/2"
 	logger = GetLogger("test", "2", "4")
-	assert.Equal(t, WarnLevel, logger.GetLevel())
+	assert.Equal(t, WarnLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Info("should not be printed")
 	logger.Warn("should be printed twice")
@@ -84,14 +84,14 @@ func TestLoggerConfig(t *testing.T) {
 	// The "test/2" logger level should be changed to DEBUG
 	logger = GetLogger("test/2")
 	logger.SetLevel(DebugLevel)
-	assert.Equal(t, DebugLevel, logger.GetLevel())
+	assert.Equal(t, DebugLevel, logger.Level())
 	logger.Debugw("should be", Bool("printed", true))
 	logger.Infow("should be printed", Int("times", 2))
 	logger.Warn("should be printed twice")
 
 	// The "test/2/3" logger should not inherit the change to the "test/2" logger since its level has been explicitly set
 	logger = GetLogger("test/2/3")
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Info("should be printed twice")
 	logger.Warn("should be printed twice")
@@ -99,7 +99,7 @@ func TestLoggerConfig(t *testing.T) {
 	// The "test/2/4" logger should inherit the change to the "test/2" logger since its level has not been explicitly set
 	// The "test/2/4" logger should not output DEBUG messages since the output level is explicitly set to WARN
 	logger = GetLogger("test/2/4")
-	assert.Equal(t, DebugLevel, logger.GetLevel())
+	assert.Equal(t, DebugLevel, logger.Level())
 	logger.Debug("should be printed")
 	logger.Info("should be printed twice")
 	logger.Warn("should be printed twice")
@@ -107,7 +107,7 @@ func TestLoggerConfig(t *testing.T) {
 	// The "test/3" logger should be configured with INFO level
 	// The "test/3" logger should write to multiple outputs
 	logger = GetLogger("test/3")
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Info("should be printed")
 	logger.Warn("should be printed twice")
@@ -115,11 +115,11 @@ func TestLoggerConfig(t *testing.T) {
 	// The "test/3/4" logger should inherit INFO level from "test/3"
 	// The "test/3/4" logger should inherit multiple outputs from "test/3"
 	logger = GetLogger("test/3/4")
-	assert.Equal(t, InfoLevel, logger.GetLevel())
+	assert.Equal(t, InfoLevel, logger.Level())
 	logger.Debug("should not be printed")
 	logger.Info("should be printed")
 	logger.Warn("should be printed twice")
 
 	//logger = GetLogger("test", "kafka")
-	//assert.Equal(t, InfoLevel, logger.GetLevel())
+	//assert.Equal(t, InfoLevel, logger.Level())
 }

--- a/pkg/logging/output.go
+++ b/pkg/logging/output.go
@@ -165,7 +165,6 @@ func (o *zapOutput) getZapFields(fields ...Field) []zap.Field {
 }
 
 func (o *zapOutput) Debug(msg string, fields ...Field) {
-	o.logger.Sugar().Info()
 	o.logger.Debug(msg, o.getZapFields(fields...)...)
 }
 

--- a/pkg/logging/output.go
+++ b/pkg/logging/output.go
@@ -93,7 +93,7 @@ func newZapOutput(logger LoggerConfig, output OutputConfig, sink SinkConfig) (*z
 		atomLevel = zap.NewAtomicLevelAt(zapcore.FatalLevel)
 	}
 
-	zapLogger, err := zapConfig.Build(zap.AddCallerSkip(2))
+	zapLogger, err := zapConfig.Build(zap.AddCallerSkip(4))
 	if err != nil {
 		return nil, err
 	}
@@ -129,33 +129,15 @@ func getWriter(url string) (zapcore.WriteSyncer, error) {
 
 // Output is a logging output
 type Output interface {
-	Debug(...interface{})
-	Debugf(template string, args ...interface{})
-	Debugw(msg string, keysAndValues ...interface{})
-
-	Info(...interface{})
-	Infof(template string, args ...interface{})
-	Infow(msg string, keysAndValues ...interface{})
-
-	Error(...interface{})
-	Errorf(template string, args ...interface{})
-	Errorw(msg string, keysAndValues ...interface{})
-
-	Fatal(...interface{})
-	Fatalf(template string, args ...interface{})
-	Fatalw(msg string, keysAndValues ...interface{})
-
-	Panic(...interface{})
-	Panicf(template string, args ...interface{})
-	Panicw(msg string, keysAndValues ...interface{})
-
-	DPanic(...interface{})
-	DPanicf(template string, args ...interface{})
-	DPanicw(msg string, keysAndValues ...interface{})
-
-	Warn(...interface{})
-	Warnf(template string, args ...interface{})
-	Warnw(msg string, keysAndValues ...interface{})
+	WithFields(fields ...Field) Output
+	Debug(msg string, fields ...Field)
+	Info(msg string, fields ...Field)
+	Error(msg string, fields ...Field)
+	Fatal(msg string, fields ...Field)
+	Panic(msg string, fields ...Field)
+	DPanic(msg string, fields ...Field)
+	Warn(msg string, fields ...Field)
+	Sync() error
 }
 
 // zapOutput is a logging output implementation
@@ -164,88 +146,54 @@ type zapOutput struct {
 	logger *zap.Logger
 }
 
-func (o *zapOutput) Debug(args ...interface{}) {
-	o.logger.Sugar().Debug(args...)
+func (o *zapOutput) WithFields(fields ...Field) Output {
+	return &zapOutput{
+		config: o.config,
+		logger: o.logger.With(o.getZapFields(fields...)...),
+	}
 }
 
-func (o *zapOutput) Debugf(template string, args ...interface{}) {
-	o.logger.Sugar().Debugf(template, args...)
+func (o *zapOutput) getZapFields(fields ...Field) []zap.Field {
+	if len(fields) == 0 {
+		return nil
+	}
+	zapFields := make([]zap.Field, len(fields))
+	for i, field := range fields {
+		zapFields[i] = field.getZapField()
+	}
+	return zapFields
 }
 
-func (o *zapOutput) Debugw(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().Debugw(msg, keysAndValues...)
+func (o *zapOutput) Debug(msg string, fields ...Field) {o.logger.Sugar().Info()
+	o.logger.Debug(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Info(args ...interface{}) {
-	o.logger.Sugar().Info(args...)
+func (o *zapOutput) Info(msg string, fields ...Field) {
+	o.logger.Info(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Infof(template string, args ...interface{}) {
-	o.logger.Sugar().Infof(template, args...)
+func (o *zapOutput) Error(msg string, fields ...Field) {
+	o.logger.Error(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Infow(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().Infow(msg, keysAndValues...)
+func (o *zapOutput) Fatal(msg string, fields ...Field) {
+	o.logger.Fatal(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Error(args ...interface{}) {
-	o.logger.Sugar().Error(args...)
+func (o *zapOutput) Panic(msg string, fields ...Field) {
+	o.logger.Panic(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Errorf(template string, args ...interface{}) {
-	o.logger.Sugar().Errorf(template, args...)
+func (o *zapOutput) DPanic(msg string, fields ...Field) {
+	o.logger.DPanic(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Errorw(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().Errorw(msg, keysAndValues...)
+func (o *zapOutput) Warn(msg string, fields ...Field) {
+	o.logger.Warn(msg, o.getZapFields(fields...)...)
 }
 
-func (o *zapOutput) Fatal(args ...interface{}) {
-	o.logger.Sugar().Fatal(args...)
-}
-
-func (o *zapOutput) Fatalf(template string, args ...interface{}) {
-	o.logger.Sugar().Fatalf(template, args)
-}
-
-func (o *zapOutput) Fatalw(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().Fatalw(msg, keysAndValues...)
-}
-
-func (o *zapOutput) Panic(args ...interface{}) {
-	o.logger.Sugar().Panic(args...)
-}
-
-func (o *zapOutput) Panicf(template string, args ...interface{}) {
-	o.logger.Sugar().Panicf(template, args...)
-}
-
-func (o *zapOutput) Panicw(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().Panicw(msg, keysAndValues...)
-}
-
-func (o *zapOutput) DPanic(args ...interface{}) {
-	o.logger.Sugar().DPanic(args...)
-}
-
-func (o *zapOutput) DPanicf(template string, args ...interface{}) {
-	o.logger.Sugar().DPanicf(template, args...)
-}
-
-func (o *zapOutput) DPanicw(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().DPanicw(msg, keysAndValues...)
-}
-
-func (o *zapOutput) Warn(args ...interface{}) {
-	o.logger.Sugar().Warn(args...)
-}
-
-func (o *zapOutput) Warnf(template string, args ...interface{}) {
-	o.logger.Sugar().Warnf(template, args...)
-}
-
-func (o *zapOutput) Warnw(msg string, keysAndValues ...interface{}) {
-	o.logger.Sugar().Warnw(msg, keysAndValues...)
+func (o *zapOutput) Sync() error {
+	return o.logger.Sync()
 }
 
 var _ Output = &zapOutput{}

--- a/pkg/logging/output.go
+++ b/pkg/logging/output.go
@@ -164,7 +164,8 @@ func (o *zapOutput) getZapFields(fields ...Field) []zap.Field {
 	return zapFields
 }
 
-func (o *zapOutput) Debug(msg string, fields ...Field) {o.logger.Sugar().Info()
+func (o *zapOutput) Debug(msg string, fields ...Field) {
+	o.logger.Sugar().Info()
 	o.logger.Debug(msg, o.getZapFields(fields...)...)
 }
 

--- a/pkg/logging/server.go
+++ b/pkg/logging/server.go
@@ -60,7 +60,7 @@ func (s *Server) GetLevel(ctx context.Context, req *logging.GetLevelRequest) (*l
 
 	names := splitLoggerName(name)
 	logger := GetLogger(names...)
-	level := logger.GetLevel()
+	level := logger.Level()
 
 	var loggerLevel logging.Level
 	switch level {


### PR DESCRIPTION
This PR refactors the `Logger` API to allow loggers to be configured without the use of concurrency primitives like `sync.Mutex` or `atomic.Value`. The `Logger` API was changed to return a new `Logger` when log levels are overridden programmatically. This ensures log levels are immutable for each `Logger` instance and eliminates the need to use `atomic.Value` when writing logs. Additionally, the `Logger` interface is modified to support typed `Field`s for structured logging, allowing fields to be added to all messages for a logger. Again, when fields are added to a logger, a new immutable `Logger` instance is constructed to avoid the use of concurrency primitives. Support for configuring typed logger `Field`s allows us to use Zap's `Logger` in the underlying `Output` implementation, rather than the less efficient `SugaredLogger`.