### PR TITLE
Add error utility to support typed errors and conversion to/from gRPC

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -210,10 +210,18 @@ func NewInternal(msg string) error {
 	return New(Internal, msg)
 }
 
+// TypeOf returns the type of the given error
+func TypeOf(err error) Type {
+	if typed, ok := err.(*TypedError); ok {
+		return typed.Type
+	}
+	return Unknown
+}
+
 // IsType checks whether the given error is of the given type
 func IsType(err error, t Type) bool {
-	if status, ok := err.(*TypedError); ok {
-		return status.Type == t
+	if typed, ok := err.(*TypedError); ok {
+		return typed.Type == t
 	}
 	return false
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,279 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Type is an error type
+type Type int
+
+const (
+	// Unknown is an unknown error type
+	Unknown Type = iota
+	// Canceled indicates a request context was canceled
+	Canceled
+	// NotFound indicates a resource was not found
+	NotFound
+	// AlreadyExists indicates a resource already exists
+	AlreadyExists
+	// Unauthorized indicates access to a resource is not authorized
+	Unauthorized
+	// Forbidden indicates the operation requested to be performed on a resource is forbidden
+	Forbidden
+	// Conflict indicates a conflict occurred during concurrent modifications to a resource
+	Conflict
+	// Invalid indicates a message or request is invalid
+	Invalid
+	// Unavailable indicates a service is not available
+	Unavailable
+	// NotSupported indicates a method is not supported
+	NotSupported
+	// Timeout indicates a request timed out
+	Timeout
+	// Internal indicates an unexpected internal error occurred
+	Internal
+)
+
+// TypedError is an typed error
+type TypedError struct {
+	// Type is the error type
+	Type Type
+	// Message is the error message
+	Message string
+}
+
+func (e *TypedError) Error() string {
+	return e.Message
+}
+
+var _ error = &TypedError{}
+
+// Status gets the gRPC status for the given error
+func Status(err error) *status.Status {
+	if err == nil {
+		return status.New(codes.OK, "")
+	}
+
+	typed, ok := err.(*TypedError)
+	if !ok {
+		return status.New(codes.Internal, err.Error())
+	}
+
+	switch typed.Type {
+	case Unknown:
+		return status.New(codes.Unknown, typed.Message)
+	case Canceled:
+		return status.New(codes.Canceled, typed.Message)
+	case NotFound:
+		return status.New(codes.NotFound, typed.Message)
+	case AlreadyExists:
+		return status.New(codes.AlreadyExists, typed.Message)
+	case Unauthorized:
+		return status.New(codes.Unauthenticated, typed.Message)
+	case Forbidden:
+		return status.New(codes.PermissionDenied, typed.Message)
+	case Conflict:
+		return status.New(codes.FailedPrecondition, typed.Message)
+	case Invalid:
+		return status.New(codes.InvalidArgument, typed.Message)
+	case Unavailable:
+		return status.New(codes.Unavailable, typed.Message)
+	case NotSupported:
+		return status.New(codes.Unimplemented, typed.Message)
+	case Timeout:
+		return status.New(codes.DeadlineExceeded, typed.Message)
+	case Internal:
+		return status.New(codes.Internal, typed.Message)
+	default:
+		return status.New(codes.Internal, err.Error())
+	}
+}
+
+// FromStatus creates a typed error from a gRPC status
+func FromStatus(status *status.Status) error {
+	switch status.Code() {
+	case codes.OK:
+		return nil
+	case codes.Unknown:
+		return NewUnknown(status.Message())
+	case codes.Canceled:
+		return NewCanceled(status.Message())
+	case codes.NotFound:
+		return NewNotFound(status.Message())
+	case codes.AlreadyExists:
+		return NewAlreadyExists(status.Message())
+	case codes.Unauthenticated:
+		return NewUnauthorized(status.Message())
+	case codes.PermissionDenied:
+		return NewForbidden(status.Message())
+	case codes.FailedPrecondition:
+		return NewConflict(status.Message())
+	case codes.InvalidArgument:
+		return NewInvalid(status.Message())
+	case codes.Unavailable:
+		return NewUnavailable(status.Message())
+	case codes.Unimplemented:
+		return NewNotSupported(status.Message())
+	case codes.DeadlineExceeded:
+		return NewTimeout(status.Message())
+	case codes.Internal:
+		return NewInternal(status.Message())
+	default:
+		return NewUnknown(status.Message())
+	}
+}
+
+// New creates a new typed error
+func New(t Type, msg string, args ...interface{}) error {
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args...)
+	}
+	return &TypedError{
+		Type:    t,
+		Message: msg,
+	}
+}
+
+// NewUnknown returns a new Unknown error
+func NewUnknown(msg string) error {
+	return New(Unknown, msg)
+}
+
+// NewCanceled returns a new Canceled error
+func NewCanceled(msg string) error {
+	return New(Canceled, msg)
+}
+
+// NewNotFound returns a new NotFound error
+func NewNotFound(msg string) error {
+	return New(NotFound, msg)
+}
+
+// NewAlreadyExists returns a new AlreadyExists error
+func NewAlreadyExists(msg string) error {
+	return New(AlreadyExists, msg)
+}
+
+// NewUnauthorized returns a new Unauthorized error
+func NewUnauthorized(msg string) error {
+	return New(Unauthorized, msg)
+}
+
+// NewForbidden returns a new Forbidden error
+func NewForbidden(msg string) error {
+	return New(Forbidden, msg)
+}
+
+// NewConflict returns a new Conflict error
+func NewConflict(msg string) error {
+	return New(Conflict, msg)
+}
+
+// NewInvalid returns a new Invalid error
+func NewInvalid(msg string) error {
+	return New(Invalid, msg)
+}
+
+// NewUnavailable returns a new Unavailable error
+func NewUnavailable(msg string) error {
+	return New(Unavailable, msg)
+}
+
+// NewNotSupported returns a new NotSupported error
+func NewNotSupported(msg string) error {
+	return New(NotSupported, msg)
+}
+
+// NewTimeout returns a new Timeout error
+func NewTimeout(msg string) error {
+	return New(Timeout, msg)
+}
+
+// NewInternal returns a new Internal error
+func NewInternal(msg string) error {
+	return New(Internal, msg)
+}
+
+// IsType checks whether the given error is of the given type
+func IsType(err error, t Type) bool {
+	if status, ok := err.(*TypedError); ok {
+		return status.Type == t
+	}
+	return false
+}
+
+// IsUnknown checks whether the given error is an Unknown error
+func IsUnknown(err error) bool {
+	return IsType(err, Unknown)
+}
+
+// IsCanceled checks whether the given error is an Canceled error
+func IsCanceled(err error) bool {
+	return IsType(err, Canceled)
+}
+
+// IsNotFound checks whether the given error is a NotFound error
+func IsNotFound(err error) bool {
+	return IsType(err, NotFound)
+}
+
+// IsAlreadyExists checks whether the given error is a AlreadyExists error
+func IsAlreadyExists(err error) bool {
+	return IsType(err, AlreadyExists)
+}
+
+// IsUnauthorized checks whether the given error is a Unauthorized error
+func IsUnauthorized(err error) bool {
+	return IsType(err, Unauthorized)
+}
+
+// IsForbidden checks whether the given error is a Forbidden error
+func IsForbidden(err error) bool {
+	return IsType(err, Forbidden)
+}
+
+// IsConflict checks whether the given error is a Conflict error
+func IsConflict(err error) bool {
+	return IsType(err, Conflict)
+}
+
+// IsInvalid checks whether the given error is an Invalid error
+func IsInvalid(err error) bool {
+	return IsType(err, Invalid)
+}
+
+// IsUnavailable checks whether the given error is an Unavailable error
+func IsUnavailable(err error) bool {
+	return IsType(err, Unavailable)
+}
+
+// IsNotSupported checks whether the given error is a NotSupported error
+func IsNotSupported(err error) bool {
+	return IsType(err, NotSupported)
+}
+
+// IsTimeout checks whether the given error is a Timeout error
+func IsTimeout(err error) bool {
+	return IsType(err, Timeout)
+}
+
+// IsInternal checks whether the given error is an Internal error
+func IsInternal(err error) bool {
+	return IsType(err, Internal)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,134 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"testing"
+)
+
+func TestFactories(t *testing.T) {
+	assert.Equal(t, Unknown, NewUnknown("").(*TypedError).Type)
+	assert.Equal(t, "Unknown", NewUnknown("Unknown").Error())
+	assert.Equal(t, Canceled, NewCanceled("").(*TypedError).Type)
+	assert.Equal(t, "Canceled", NewCanceled("Canceled").Error())
+	assert.Equal(t, NotFound, NewNotFound("").(*TypedError).Type)
+	assert.Equal(t, "NotFound", NewNotFound("NotFound").Error())
+	assert.Equal(t, AlreadyExists, NewAlreadyExists("").(*TypedError).Type)
+	assert.Equal(t, "AlreadyExists", NewAlreadyExists("AlreadyExists").Error())
+	assert.Equal(t, Unauthorized, NewUnauthorized("").(*TypedError).Type)
+	assert.Equal(t, "Unauthorized", NewUnauthorized("Unauthorized").Error())
+	assert.Equal(t, Forbidden, NewForbidden("").(*TypedError).Type)
+	assert.Equal(t, "Forbidden", NewForbidden("Forbidden").Error())
+	assert.Equal(t, Conflict, NewConflict("").(*TypedError).Type)
+	assert.Equal(t, "Conflict", NewConflict("Conflict").Error())
+	assert.Equal(t, Invalid, NewInvalid("").(*TypedError).Type)
+	assert.Equal(t, "Invalid", NewInvalid("Invalid").Error())
+	assert.Equal(t, Unavailable, NewUnavailable("").(*TypedError).Type)
+	assert.Equal(t, "Unavailable", NewUnavailable("Unavailable").Error())
+	assert.Equal(t, NotSupported, NewNotSupported("").(*TypedError).Type)
+	assert.Equal(t, "NotSupported", NewNotSupported("NotSupported").Error())
+	assert.Equal(t, Timeout, NewTimeout("").(*TypedError).Type)
+	assert.Equal(t, "Timeout", NewTimeout("Timeout").Error())
+	assert.Equal(t, Internal, NewInternal("").(*TypedError).Type)
+	assert.Equal(t, "Internal", NewInternal("Internal").Error())
+}
+
+func TestPredicates(t *testing.T) {
+	assert.False(t, IsUnknown(errors.New("Unknown")))
+	assert.True(t, IsUnknown(NewUnknown("Unknown")))
+	assert.False(t, IsCanceled(errors.New("Canceled")))
+	assert.True(t, IsCanceled(NewCanceled("Canceled")))
+	assert.False(t, IsNotFound(errors.New("NotFound")))
+	assert.True(t, IsNotFound(NewNotFound("NotFound")))
+	assert.False(t, IsAlreadyExists(errors.New("AlreadyExists")))
+	assert.True(t, IsAlreadyExists(NewAlreadyExists("AlreadyExists")))
+	assert.False(t, IsUnauthorized(errors.New("Unauthorized")))
+	assert.True(t, IsUnauthorized(NewUnauthorized("Unauthorized")))
+	assert.False(t, IsForbidden(errors.New("Forbidden")))
+	assert.True(t, IsForbidden(NewForbidden("Forbidden")))
+	assert.False(t, IsConflict(errors.New("Conflict")))
+	assert.True(t, IsConflict(NewConflict("Conflict")))
+	assert.False(t, IsInvalid(errors.New("Invalid")))
+	assert.True(t, IsInvalid(NewInvalid("Invalid")))
+	assert.False(t, IsUnavailable(errors.New("Unavailable")))
+	assert.True(t, IsUnavailable(NewUnavailable("Unavailable")))
+	assert.False(t, IsNotSupported(errors.New("NotSupported")))
+	assert.True(t, IsNotSupported(NewNotSupported("NotSupported")))
+	assert.False(t, IsTimeout(errors.New("Timeout")))
+	assert.True(t, IsTimeout(NewTimeout("Timeout")))
+	assert.False(t, IsInternal(errors.New("Internal")))
+	assert.True(t, IsInternal(NewInternal("Internal")))
+}
+
+func TestErrorToStatus(t *testing.T) {
+	assert.Equal(t, codes.OK, Status(nil).Code())
+	assert.Equal(t, "", Status(nil).Message())
+	assert.Equal(t, codes.Unknown, Status(NewUnknown("")).Code())
+	assert.Equal(t, "Unknown", Status(NewUnknown("Unknown")).Message())
+	assert.Equal(t, codes.Canceled, Status(NewCanceled("")).Code())
+	assert.Equal(t, "Canceled", Status(NewCanceled("Canceled")).Message())
+	assert.Equal(t, codes.NotFound, Status(NewNotFound("")).Code())
+	assert.Equal(t, "NotFound", Status(NewNotFound("NotFound")).Message())
+	assert.Equal(t, codes.AlreadyExists, Status(NewAlreadyExists("")).Code())
+	assert.Equal(t, "AlreadyExists", Status(NewAlreadyExists("AlreadyExists")).Message())
+	assert.Equal(t, codes.Unauthenticated, Status(NewUnauthorized("")).Code())
+	assert.Equal(t, "Unauthorized", Status(NewUnauthorized("Unauthorized")).Message())
+	assert.Equal(t, codes.PermissionDenied, Status(NewForbidden("")).Code())
+	assert.Equal(t, "Forbidden", Status(NewForbidden("Forbidden")).Message())
+	assert.Equal(t, codes.FailedPrecondition, Status(NewConflict("")).Code())
+	assert.Equal(t, "Conflict", Status(NewConflict("Conflict")).Message())
+	assert.Equal(t, codes.InvalidArgument, Status(NewInvalid("")).Code())
+	assert.Equal(t, "Invalid", Status(NewInvalid("Invalid")).Message())
+	assert.Equal(t, codes.Unavailable, Status(NewUnavailable("")).Code())
+	assert.Equal(t, "Unavailable", Status(NewUnavailable("Unavailable")).Message())
+	assert.Equal(t, codes.Unimplemented, Status(NewNotSupported("")).Code())
+	assert.Equal(t, "NotSupported", Status(NewNotSupported("NotSupported")).Message())
+	assert.Equal(t, codes.DeadlineExceeded, Status(NewTimeout("")).Code())
+	assert.Equal(t, "Timeout", Status(NewTimeout("Timeout")).Message())
+	assert.Equal(t, codes.Internal, Status(NewInternal("")).Code())
+	assert.Equal(t, "Internal", Status(NewInternal("Internal")).Message())
+}
+
+func TestStatusToError(t *testing.T) {
+	assert.Nil(t, FromStatus(status.New(codes.OK, "")))
+	assert.True(t, IsUnknown(FromStatus(status.New(codes.Unknown, ""))))
+	assert.Equal(t, "Unknown", FromStatus(status.New(codes.Unknown, "Unknown")).Error())
+	assert.True(t, IsCanceled(FromStatus(status.New(codes.Canceled, ""))))
+	assert.Equal(t, "Canceled", FromStatus(status.New(codes.Canceled, "Canceled")).Error())
+	assert.True(t, IsNotFound(FromStatus(status.New(codes.NotFound, ""))))
+	assert.Equal(t, "NotFound", FromStatus(status.New(codes.NotFound, "NotFound")).Error())
+	assert.True(t, IsAlreadyExists(FromStatus(status.New(codes.AlreadyExists, ""))))
+	assert.Equal(t, "AlreadyExists", FromStatus(status.New(codes.AlreadyExists, "AlreadyExists")).Error())
+	assert.True(t, IsUnauthorized(FromStatus(status.New(codes.Unauthenticated, ""))))
+	assert.Equal(t, "Unauthenticated", FromStatus(status.New(codes.Unauthenticated, "Unauthenticated")).Error())
+	assert.True(t, IsForbidden(FromStatus(status.New(codes.PermissionDenied, ""))))
+	assert.Equal(t, "PermissionDenied", FromStatus(status.New(codes.PermissionDenied, "PermissionDenied")).Error())
+	assert.True(t, IsConflict(FromStatus(status.New(codes.FailedPrecondition, ""))))
+	assert.Equal(t, "FailedPrecondition", FromStatus(status.New(codes.FailedPrecondition, "FailedPrecondition")).Error())
+	assert.True(t, IsInvalid(FromStatus(status.New(codes.InvalidArgument, ""))))
+	assert.Equal(t, "InvalidArgument", FromStatus(status.New(codes.InvalidArgument, "InvalidArgument")).Error())
+	assert.True(t, IsUnavailable(FromStatus(status.New(codes.Unavailable, ""))))
+	assert.Equal(t, "Unavailable", FromStatus(status.New(codes.Unavailable, "Unavailable")).Error())
+	assert.True(t, IsNotSupported(FromStatus(status.New(codes.Unimplemented, ""))))
+	assert.Equal(t, "Unimplemented", FromStatus(status.New(codes.Unimplemented, "Unimplemented")).Error())
+	assert.True(t, IsTimeout(FromStatus(status.New(codes.DeadlineExceeded, ""))))
+	assert.Equal(t, "DeadlineExceeded", FromStatus(status.New(codes.DeadlineExceeded, "DeadlineExceeded")).Error())
+	assert.True(t, IsInternal(FromStatus(status.New(codes.Internal, ""))))
+	assert.Equal(t, "Internal", FromStatus(status.New(codes.Internal, "Internal")).Error())
+}


### PR DESCRIPTION
This PR adds an `errors` package for creating and managing typed `error`s in Go. These errors should be used throughout µONOS services written in Go.

To create a typed error, simply call the associated factory function:

```go
func (s *Store) GetFoo(ctx context.Context, id ID) (*Foo, error) {
    entry, err := s.foos.Get(ctx, string(id))
    if err != nil {
        // Return a Canceled error if the context was canceled
        if err == context.Canceled {
            return nil, errors.NewCanceled(err.String())
        }
        // Return a Conflict error is a concurrent modification error occurred
        if err.String() == "concurrent modification" {
            return nil, errors.NewConflict(err.String())
        }
        // Otherwise, return an Unknown error
        return nil, errors.NewUnknown(err.String())
    }

    // Return a NotFound error if the entry is not found
    if entry == nil {
        return nil, errors.NewNotFound("%s not found", id)
    }

    ...
    return foo, nil
}
```

The `errors` package provides utilities for converting onos-lib-go errors into gRPC error `Status` objects. To get a `status.Status` for an error, just use `errors.Status`:

````go
func (s *Server) GetTermination(ctx context.Context, req *termapi.GetTerminationRequest) (*termapi.GetTerminationResponse, error) {
    term, err := s.store.GetTermination(ctx, req.ID)

    // If an error was returned, convert it to a gRPC error so the associated error code is returned to the client
    if err != nil {
        return nil, errors.Status(err).Err()
    }

    return &termapi.GetTerminationResponse{
        Term: term,
    }, nil
}
````

And gRPC errors can be converted back to onos-lib-go errors on the client side:

```go
res, reqErr := client.GetTermination(ctx, req)
if reqErr != nil {
    st, _ := status.FromErr(reqErr)
    err := errors.FromStatus(st)
}
```

Given an onos-lib-go error, the type of the error can easily be checked using a series of predicates:

```go
if errors.IsNotFound(err) {
    ...
} else if errors.IsAlreadyExists(err) {
    ...
} else if errors.IsConflict(err) {
    ...
} else {
    ...
}
```

Or you can use a switch:

```go
switch errors.TypeOf(err) {
case errors.NotFound:
    ...
case errors.AlreadyExists:
    ...
case errors.Conflict:
    ...
}
```