### PR TITLE
Close channel in controller activator to initiate graceful controller shutdown 

### DIFF
--- a/pkg/controller/activator.go
+++ b/pkg/controller/activator.go
@@ -27,10 +27,12 @@ type Activator interface {
 
 // UnconditionalActivator activates controllers on all nodes at all times
 type UnconditionalActivator struct {
+	ch chan<- bool
 }
 
 // Start starts the activator
 func (a *UnconditionalActivator) Start(ch chan<- bool) error {
+	a.ch = ch
 	go func() {
 		ch <- true
 	}()
@@ -39,7 +41,9 @@ func (a *UnconditionalActivator) Start(ch chan<- bool) error {
 
 // Stop stops the activator
 func (a *UnconditionalActivator) Stop() {
-
+	if a.ch != nil {
+		close(a.ch)
+	}
 }
 
 var _ Activator = &UnconditionalActivator{}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -157,6 +157,10 @@ func (c *Controller) Start() error {
 					active = false
 				}
 			}
+			if active {
+				log.Infof("Deactivating controller %s", c.name)
+				c.deactivate()
+			}
 		}
 	}()
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -157,10 +157,10 @@ func (c *Controller) Start() error {
 					active = false
 				}
 			}
-			if active {
-				log.Infof("Deactivating controller %s", c.name)
-				c.deactivate()
-			}
+		}
+		if active {
+			log.Infof("Deactivating controller %s", c.name)
+			c.deactivate()
 		}
 	}()
 	return nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -60,6 +60,7 @@ func TestController(t *testing.T) {
 			wg.Done()
 			return nil
 		})
+	watcher.EXPECT().Stop()
 
 	partitions := 3
 	partitioner := NewMockWorkPartitioner(ctrl)


### PR DESCRIPTION
This PR ensures all loops within a controller are shutdown when the controller is `Stop()`ed. To stop the controller, the activator's `Stop()` method is called. Activators should close the activator channel when stopped. When the activator channel is closed, the controller activator loop will deactivate the controller if active, closing watchers. The controller will be shutdown asynchronously.