### PR TITLE
Add default sink to logger configurations

### DIFF
--- a/pkg/logging/config.go
+++ b/pkg/logging/config.go
@@ -65,14 +65,16 @@ type Config struct {
 
 // GetRootLogger returns the root logger configuration
 func (c Config) GetRootLogger() LoggerConfig {
-	root, ok := c.Loggers[rootLoggerName]
-	if ok {
-		if root.Output == nil {
-			root.Output = map[string]OutputConfig{}
+	root := c.Loggers[rootLoggerName]
+	if root.Output == nil {
+		defaultSink := ""
+		root.Output = map[string]OutputConfig{
+			"": {
+				Sink: &defaultSink,
+			},
 		}
-		return root
 	}
-	return LoggerConfig{Output: map[string]OutputConfig{}}
+	return root
 }
 
 // GetLoggers returns the configured loggers
@@ -109,7 +111,11 @@ func (c Config) GetLogger(name string) (LoggerConfig, bool) {
 
 // GetSinks returns the configured sinks
 func (c Config) GetSinks() []SinkConfig {
-	sinks := make([]SinkConfig, 0, len(c.Sinks))
+	sinks := []SinkConfig{
+		{
+			Name: "",
+		},
+	}
 	for name, sink := range c.Sinks {
 		sink.Name = name
 		sinks = append(sinks, sink)
@@ -119,6 +125,11 @@ func (c Config) GetSinks() []SinkConfig {
 
 // GetSink returns a sink by name
 func (c Config) GetSink(name string) (SinkConfig, bool) {
+	if name == "" {
+		return SinkConfig{
+			Name: "",
+		}, true
+	}
 	sink, ok := c.Sinks[name]
 	if ok {
 		sink.Name = name

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -49,6 +49,11 @@ func GetLogger(names ...string) Logger {
 	return root.GetLogger(names...)
 }
 
+// SetLevel sets the root logger level
+func SetLevel(level Level) {
+	root.SetLevel(level)
+}
+
 // Logger represents an abstract logging interface.
 type Logger interface {
 	Output

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -21,6 +21,14 @@ import (
 	"testing"
 )
 
+func TestDefaultLogger(t *testing.T) {
+	logger := GetLogger()
+	logger.Info("foo: bar")
+	SetLevel(InfoLevel)
+	logger.Info("bar: baz")
+	logger.Debug("baz: bar")
+}
+
 func TestLoggerConfig(t *testing.T) {
 	config := Config{}
 	bytes, err := ioutil.ReadFile("test.yaml")


### PR DESCRIPTION
This PR adds a default stdout sink to logger configurations when no sink is present. Additionally, a global `SetLevel` function allows the root log level to be configured in code. This allows tests to simply call `logging.SetLevel(logging.InfoLevel)` to enable _info_ level logging to stdout.