### PR TITLE
Added function to use a config directory other than .onos

### DIFF
--- a/pkg/logging/config.go
+++ b/pkg/logging/config.go
@@ -275,13 +275,12 @@ type KafkaSinkConfig struct {
 	Brokers []string `yaml:"brokers"`
 }
 
-
 func customLoad(config *Config, dir string) error {
 	home, err := homedir.Dir()
 	if err != nil {
 		return err
 	}
-		
+
 	// Set the file name of the configurations file
 	viper.SetConfigName("logging")
 
@@ -302,7 +301,6 @@ func customLoad(config *Config, dir string) error {
 		return err
 	}
 	return nil
-
 
 }
 

--- a/pkg/logging/config.go
+++ b/pkg/logging/config.go
@@ -275,19 +275,19 @@ type KafkaSinkConfig struct {
 	Brokers []string `yaml:"brokers"`
 }
 
-// load loads the configuration
-func load(config *Config) error {
+
+func customLoad(config *Config, dir string) error {
 	home, err := homedir.Dir()
 	if err != nil {
 		return err
 	}
-
+		
 	// Set the file name of the configurations file
 	viper.SetConfigName("logging")
 
 	// Set the path to look for the configurations file
-	viper.AddConfigPath("./" + configDir + "/config")
-	viper.AddConfigPath(home + "/" + configDir + "/config")
+	viper.AddConfigPath("./" + dir + "/config")
+	viper.AddConfigPath(home + "/" + dir + "/config")
 	viper.AddConfigPath("/etc/onos/config")
 	viper.AddConfigPath(".")
 
@@ -302,4 +302,11 @@ func load(config *Config) error {
 		return err
 	}
 	return nil
+
+
+}
+
+// load loads the configuration
+func load(config *Config) error {
+	return customLoad(config, configDir)
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -16,6 +16,10 @@ var root *zapLogger
 
 const nameSep = "/"
 
+
+// Replacement for the normal init 
+// Can be called if a configuration folder other than .onos is to be used. 
+// Else just call GetLogger as usual. 
 func CustomInit(dir string) {
 	config := Config{}
 	if err := customLoad(&config, dir); err != nil {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -16,10 +16,9 @@ var root *zapLogger
 
 const nameSep = "/"
 
-
-// Replacement for the normal init 
-// Can be called if a configuration folder other than .onos is to be used. 
-// Else just call GetLogger as usual. 
+// Replacement for the normal init
+// Can be called if a configuration folder other than .onos is to be used.
+// Else just call GetLogger as usual.
 func CustomInit(dir string) {
 	config := Config{}
 	if err := customLoad(&config, dir); err != nil {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -16,7 +16,17 @@ var root *zapLogger
 
 const nameSep = "/"
 
-func init() {
+func CustomInit(dir string) {
+	config := Config{}
+	if err := customLoad(&config, dir); err != nil {
+		panic(err)
+	} else if err := configure(config); err != nil {
+		panic(err)
+	}
+
+}
+
+func rootInit() {
 	config := Config{}
 	if err := load(&config); err != nil {
 		panic(err)
@@ -41,6 +51,9 @@ func configure(config Config) error {
 // string on backslashes.
 // If multiple names are provided, the set of names defines the logger ancestry.
 func GetLogger(names ...string) Logger {
+	if root == nil {
+		rootInit()
+	}
 	if len(names) == 0 {
 		pkg, ok := getCallerPackage()
 		if !ok {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -16,7 +16,7 @@ var root *zapLogger
 
 const nameSep = "/"
 
-// Replacement for the normal init
+// CustomInit replacement for the normal init
 // Can be called if a configuration folder other than .onos is to be used.
 // Else just call GetLogger as usual.
 func CustomInit(dir string) {


### PR DESCRIPTION
Hi. 

I am not sure if this project is still under active use or if a pull request is appreciated. 
But I found that the logging library here gave us with a simple method of logging to a Kafka broker. 

The only issue I had is that we in our project would like to save all configurations in the same directory, meaning that the standard ".onos" folder is a hard no. 

This pull request aims to fix that by introducing  the function ```CustomInit``` function.
It gives the user of the library a chance of initializing with a custom directory name. 

This is done in our case with a wrapper library which calls ```CustomInt``` in the init function. 
The wrapper library can then be added to use a custom directory. 
Code below is how the basic wrapper could look

```
import (
	logging "github.com/onosproject/onos-lib-go/pkg/logging"
)
func init() {
    logging.CustomInit(".myconfig")
}
func GetLogger(names ...string) logging.Logger {
    return logging.GetLogger(names)
}
``` 

This means that the init function in the file pkg/logging/logger.go had to be removed, else it would init on load before the user can call ```CustomInit```.
A nil check for the variable root has been added in the function ```GetLogger``` to handle the cases where a user doesn't want to use the ```CustomInit``` function. 
This means that users which want the library to work the same as before can simply call the ```GetLogger``` and get the same expected behaviour. 
This adds an extra check every time the function is called which is extra overhead. But I'm not sure if that amount is of any care to the project? 

Again, I don't know if anyone still manages this repository and if pull requests are appreciated. 
I'd be happy to change the code or further explain my reasoning if anyone is interest!
Thank you for taking the time to read this. 