### PR TITLE
Fix reading 0 bits

### DIFF
--- a/pkg/asn1/aper/aper.go
+++ b/pkg/asn1/aper/aper.go
@@ -44,6 +44,10 @@ func GetBitString(srcBytes []byte, bitsOffset uint, numBits uint) (dstBytes []by
 		err = fmt.Errorf("Get bits overflow, requireBits: %d, leftBits: %d", numBits, bitsLeft)
 		return
 	}
+	if numBits == 0 {
+		err = fmt.Errorf("Get bits called with zero numBits")
+		return
+	}
 	byteLen := (bitsOffset + numBits + 7) >> 3
 	numBitsByteLen := (numBits + 7) >> 3
 	dstBytes = make([]byte, numBitsByteLen)


### PR DESCRIPTION
I was getting errors where the decoder wanted to decode 0 bits as a field value and fell over. This change adds a graceful failure by emitting and error message